### PR TITLE
Update LP links to use Sushiswap Vision

### DIFF
--- a/src/static/js/ethers_helper.js
+++ b/src/static/js/ethers_helper.js
@@ -1257,7 +1257,7 @@ function getUniPrices(tokens, prices, pool)
       print_price(chain="eth") {
         const poolUrl = pool.is1inch ? "https://1inch.exchange/#/dao/pools" :
         pool.symbol.includes("LSLP") ? `https://info.linkswap.app/pair/${pool.address}` :
-          pool.symbol.includes("SLP") ?  `http://sushiswap.fi/pair/${pool.address}` :
+          pool.symbol.includes("SLP") ?  `https://sushiswap.vision/pair/${pool.address}` :
             pool.symbol.includes("Cake") ?  `https://pancakeswap.info/pair/${pool.address}` :  
             pool.symbol.includes("PGL") ?  `https://info.pangolin.exchange/#/pair/${pool.address}` :  
             pool.name.includes("Value LP") ?  `https://info.vswap.fi/pool/${pool.address}` :  
@@ -1427,7 +1427,7 @@ function getWrapPrices(tokens, prices, pool)
   if (wrappedToken.token0 != null) { //Uniswap
     const uniPrices = getUniPrices(tokens, prices, wrappedToken);
     const poolUrl = pool.is1inch ? "https://1inch.exchange/#/dao/pools" :
-    pool.symbol.includes("SLP") ?  `http://sushiswap.fi/pair/${wrappedToken.address}` :
+    pool.symbol.includes("SLP") ?  `https://sushiswap.vision/pair/${wrappedToken.address}` :
     (pool.symbol.includes("Cake") || pool.symbol.includes("Pancake")) ?  `http://pancakeswap.info/pair/${wrappedToken.address}`
       : `http://uniswap.info/pair/${wrappedToken.address}`;
     const name = `Wrapped <a href='${poolUrl}' target='_blank'>${uniPrices.stakeTokenTicker}</a>`;

--- a/src/static/js/eyo.js
+++ b/src/static/js/eyo.js
@@ -61,7 +61,7 @@ async function main() {
     }
     let turl; 
     if (lp == "sushiswap") {
-        turl = 'https://sushiswap.fi/pair/'
+        turl = 'https://sushiswap.vision/pair/'
     } 
     else if (lp == 'uniswap') {
         turl = 'https://info.uniswap.org/pair/'

--- a/src/views/pages/yam/index.ejs
+++ b/src/views/pages/yam/index.ejs
@@ -7,7 +7,7 @@
 <pre id="log">
 *************** 👨‍🌾 UNOFFICIAL YAM-ETH SLP YIELD FARMING CALCULATOR 👨‍🌾 ***************
 INFO  : https://yam.finance/farm
-POOL  : https://sushiswap.fi/pair/0x0f82e57804d0b1f6fab2370a43dcfad3c7cb239c
+POOL  : https://sushiswap.vision/pair/0x0f82e57804d0b1f6fab2370a43dcfad3c7cb239c
 ***************************************************************************************
 
 </pre>


### PR DESCRIPTION
The current link to LP tokens for Sushiswap are broken since sushiswap.fi redirects to the sushi.com homepage 

Example: From [https://vfat.tools/basketdao/](https://vfat.tools/basketdao/) click the `[BASK]-[WETH] SLP`  pool. It'll send you to [http://sushiswap.fi/pair/0x34D25a4749867eF8b62A0CD1e2d7B4F7aF167E01](http://sushiswap.fi/pair/0x34D25a4749867eF8b62A0CD1e2d7B4F7aF167E01) then redirects to sushi.com. 

This PR replaces the sushiswap.fi base URLs for [sushiswap.vision](https://sushiswap.vision)

We can change this if the Sushi team does a 301 redirect for sushiswap.fi -> sushi.com