### PR TITLE
Fixes #398: matic/polyfox calling wrong chef function.

### DIFF
--- a/src/static/js/matic_polyfox.js
+++ b/src/static/js/matic_polyfox.js
@@ -23,7 +23,7 @@ async function main() {
    if(currentBlock < startBlock){
      _print(`Rewards start at block ${startBlock}\n`);
    }else{
-    rewardsPerWeek = await FOX_CHEF.krillPerBlock() /1e18
+    rewardsPerWeek = await FOX_CHEF.foxPerBlock() /1e18
       * 604800 / 2.1;
    }
 


### PR DESCRIPTION
Renames function call to be in line with Polyfox contract instead of Polywhale contract.