### PR TITLE
Display notification for incorrect network & manage related interactions

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -27,6 +27,193 @@ window.asciichart = require("asciichart");
 window.AsciiTable = require("./ascii-table");
 window.Diff = require("diff");
 window.ETHEREUM_NODE_URL = 'aHR0cHM6Ly9tYWlubmV0LmluZnVyYS5pby92My9hNmYzNmI4OWM0OGM0ZmE4YjE0NjYwNWY2ZDdhNWI2Zg==';
+window.NETWORKS = {
+  ETHEREUM: {
+    "chainId": '0x1',
+    "chainName": "Ethereum Mainnet",
+    "nativeCurrency": {
+      "name": "Ether",
+      "symbol": "ETH",
+      "decimals": 18
+    },
+    "rpcUrls": [
+      "https://mainnet.infura.io/v3/${INFURA_API_KEY}",
+      "wss://mainnet.infura.io/ws/v3/${INFURA_API_KEY}",
+      "https://api.mycryptoapi.com/eth",
+      "https://cloudflare-eth.com"
+    ],
+    "blockExplorerUrls": [
+      {
+        "name": "etherscan",
+        "url": "https://etherscan.io",
+        "standard": "EIP3091"
+      }
+    ]
+  },
+  BINANCE_SMART_CHAIN: {
+    "chainId": "0x38",
+    "chainName": "Binance Smart Chain Mainnet",
+    "nativeCurrency": {
+      "name": "Binance Chain Native Token",
+      "symbol": "BNB",
+      "decimals": 18
+    },
+    "rpcUrls": [
+      "https://bsc-dataseed1.binance.org",
+      "https://bsc-dataseed2.binance.org",
+      "https://bsc-dataseed3.binance.org",
+      "https://bsc-dataseed4.binance.org",
+      "https://bsc-dataseed1.defibit.io",
+      "https://bsc-dataseed2.defibit.io",
+      "https://bsc-dataseed3.defibit.io",
+      "https://bsc-dataseed4.defibit.io",
+      "https://bsc-dataseed1.ninicoin.io",
+      "https://bsc-dataseed2.ninicoin.io",
+      "https://bsc-dataseed3.ninicoin.io",
+      "https://bsc-dataseed4.ninicoin.io",
+      "wss://bsc-ws-node.nariox.org"
+    ],
+    "blockExplorerUrls": [
+      {
+        "name": "bscscan",
+        "url": "https://bscscan.com",
+        "standard": "EIP3091"
+      }
+    ],
+  },
+  HECO: {
+    "chainId": "0x80",
+    "chainName": "Huobi ECO Chain Mainnet",
+    "nativeCurrency": {
+      "name": "Huobi ECO Chain Native Token",
+      "symbol": "HT",
+      "decimals": 18
+    },
+    "rpcUrls": [
+      "https://http-mainnet.hecochain.com",
+      "wss://ws-mainnet.hecochain.com"
+    ],
+    "blockExplorerUrls": [],
+  },
+  POLYGON: {
+    "chainId": "0x89",
+    "chainName": "Matic Mainnet",
+    "nativeCurrency": {
+      "name": "Matic",
+      "symbol": "MATIC",
+      "decimals": 18
+    },
+    "rpcUrls": [
+      "https://rpc-mainnet.matic.network",
+      "wss://ws-mainnet.matic.network"
+    ],
+    "blockExplorerUrls": [],
+  },
+  XDAI: {
+    "chainId": "0x64",
+    "chainName": "xDAI Chain",
+    "nativeCurrency": {
+      "name": "xDAI",
+      "symbol": "xDAI",
+      "decimals": 18
+    },
+    "rpcUrls": [
+      "https://rpc.xdaichain.com",
+      "https://xdai.poanetwork.dev",
+      "wss://rpc.xdaichain.com/wss",
+      "wss://xdai.poanetwork.dev/wss",
+      "http://xdai.poanetwork.dev",
+      "https://dai.poa.network",
+      "ws://xdai.poanetwork.dev:8546"
+    ],
+    "blockExplorerUrls": [],
+  },
+  AVALANCHE: {
+    "chainId": "0xA86A",
+    "chainName": "Avalanche Mainnet",
+    "nativeCurrency": {
+      "name": "Avalanche",
+      "symbol": "AVAX",
+      "decimals": 18
+    },
+    "rpcUrls": [
+      "https://api.avax.network/ext/bc/C/rpc"
+    ],
+    "blockExplorerUrls": [],
+  },
+  FANTOM: {
+    "chainId": "0xFA",
+    "chainName": "Fantom Opera",
+    "nativeCurrency": {
+      "name": "Fantom",
+      "symbol": "FTM",
+      "decimals": 18
+    },
+    "rpcUrls": [
+      "https://rpcapi.fantom.network"
+    ],
+    "blockExplorerUrls": [
+      {
+        "name": "ftmscan",
+        "url": "https://ftmscan.com",
+        "icon": "ftmscan",
+        "standard": "EIP3091"
+      }
+    ],
+  },
+  HARMONY_S0: {
+    "chainId": "0x63564C40",
+    "chainName": "Harmony Mainnet Shard 0",
+    "nativeCurrency": {
+      "name": "ONE",
+      "symbol": "ONE",
+      "decimals": 18
+    },
+    "rpcUrls": [
+      "https://api.harmony.one"
+    ],
+    "blockExplorerUrls": [],
+  },
+  HARMONY_S1: {
+    "chainId": "0x63564C41",
+    "chainName": "Harmony Mainnet Shard 1",
+    "nativeCurrency": {
+      "name": "ONE",
+      "symbol": "ONE",
+      "decimals": 18
+    },
+    "rpcUrls": [
+      "https://s1.api.harmony.one"
+    ],
+    "blockExplorerUrls": [],
+  },
+  HARMONY_S2: {
+    "chainId": "0x63564C42",
+    "chainName": "Harmony Mainnet Shard 2",
+    "nativeCurrency": {
+      "name": "ONE",
+      "symbol": "ONE",
+      "decimals": 18
+    },
+    "rpcUrls": [
+      "https://s2.api.harmony.one"
+    ],
+    "blockExplorerUrls": [],
+  },
+  HARMONY_S3: {
+    "chainId": "0x63564C43",
+    "chainName": "Harmony Mainnet Shard 3",
+    "nativeCurrency": {
+      "name": "ONE",
+      "symbol": "ONE",
+      "decimals": 18
+    },
+    "rpcUrls": [
+      "https://s3.api.harmony.one"
+    ],
+    "blockExplorerUrls": [],
+  },
+}
 
 const infuraId = atob(window.ETHEREUM_NODE_URL).split('/').pop()
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -92,8 +92,7 @@ window.NETWORKS = {
     "rpcUrls": [
       "https://http-mainnet.hecochain.com",
       "wss://ws-mainnet.hecochain.com"
-    ],
-    "blockExplorerUrls": [],
+    ]
   },
   POLYGON: {
     "chainId": "0x89",
@@ -106,8 +105,7 @@ window.NETWORKS = {
     "rpcUrls": [
       "https://rpc-mainnet.matic.network",
       "wss://ws-mainnet.matic.network"
-    ],
-    "blockExplorerUrls": [],
+    ]
   },
   XDAI: {
     "chainId": "0x64",
@@ -125,8 +123,7 @@ window.NETWORKS = {
       "http://xdai.poanetwork.dev",
       "https://dai.poa.network",
       "ws://xdai.poanetwork.dev:8546"
-    ],
-    "blockExplorerUrls": [],
+    ]
   },
   AVALANCHE: {
     "chainId": "0xA86A",
@@ -138,8 +135,7 @@ window.NETWORKS = {
     },
     "rpcUrls": [
       "https://api.avax.network/ext/bc/C/rpc"
-    ],
-    "blockExplorerUrls": [],
+    ]
   },
   FANTOM: {
     "chainId": "0xFA",
@@ -171,8 +167,7 @@ window.NETWORKS = {
     },
     "rpcUrls": [
       "https://api.harmony.one"
-    ],
-    "blockExplorerUrls": [],
+    ]
   },
   HARMONY_S1: {
     "chainId": "0x63564C41",
@@ -184,8 +179,7 @@ window.NETWORKS = {
     },
     "rpcUrls": [
       "https://s1.api.harmony.one"
-    ],
-    "blockExplorerUrls": [],
+    ]
   },
   HARMONY_S2: {
     "chainId": "0x63564C42",
@@ -197,8 +191,7 @@ window.NETWORKS = {
     },
     "rpcUrls": [
       "https://s2.api.harmony.one"
-    ],
-    "blockExplorerUrls": [],
+    ]
   },
   HARMONY_S3: {
     "chainId": "0x63564C43",
@@ -210,8 +203,7 @@ window.NETWORKS = {
     },
     "rpcUrls": [
       "https://s3.api.harmony.one"
-    ],
-    "blockExplorerUrls": [],
+    ]
   },
 }
 

--- a/src/static/js/ethers_helper.js
+++ b/src/static/js/ethers_helper.js
@@ -57,6 +57,10 @@ const init_wallet = async function (callback) {
       start(callback);
     } else {
       _print(`You are connected to ${networkNameFromId(connectedNetwork.chainId)}, please switch to ${targetNetwork.chainName} network`)
+      if (window.ethereum && targetNetwork.chainId !== '0x1') {
+        _print('')
+        _print_link("[SWITCH NETWORK]", () => switchNetwork(targetNetwork), "connect_wallet_button")
+      }
       hideLoading()
     }
   } else {
@@ -141,6 +145,11 @@ async function init_ethers() {
   return App
 }
 
+const switchNetwork = async function(network) {
+  await window.ethereum.request({method: 'wallet_addEthereumChain', params: [network]}).catch()
+  window.location.reload()
+}
+
 const changeWallet = async function() {
   let cached = window.web3Modal.cachedProvider
   window.web3Modal.clearCachedProvider()
@@ -186,6 +195,10 @@ const connectWallet = async function(callback) {
       button.remove()
 
       _print(`You are connected to ${networkNameFromId(connectedNetwork.chainId)}, please switch to ${targetNetwork.chainName} network`)
+      if (window.ethereum && targetNetwork.chainId !== '0x1') {
+        _print('')
+        _print_link("[SWITCH NETWORK]", () => switchNetwork(targetNetwork), "connect_wallet_button")
+      }
       hideLoading()
     }
 

--- a/src/static/js/ethers_helper.js
+++ b/src/static/js/ethers_helper.js
@@ -1,20 +1,69 @@
 
 let walletProvider = undefined
 
+const networkNameFromId = function (id) {
+  for(let network of Object.values(window.NETWORKS)) {
+    let networkId = parseInt(network.chainId, 16)
+    if (networkId === id) {
+      return network.chainName
+    }
+  }
+  return "Unknown Network"
+}
+
+const pageNetwork = function() {
+  let network = window.location.pathname.split("/")[1]
+  if (network.toLowerCase() === 'bsc') {
+    return window.NETWORKS.BINANCE_SMART_CHAIN
+  }
+  if (network.toLowerCase() === 'heco') {
+    return window.NETWORKS.HECO
+  }
+  if (network.toLowerCase() === 'polygon') {
+    return window.NETWORKS.POLYGON
+  }
+  if (network.toLowerCase() === 'xdai') {
+    return window.NETWORKS.XDAI
+  }
+  if (network.toLowerCase() === 'fantom') {
+    return window.NETWORKS.FANTOM
+  }
+  if (network.toLowerCase() === 'harmony') {
+    return window.NETWORKS.HARMONY_S0
+  }
+  if (network.toLowerCase() === 'avax') {
+    return window.NETWORKS.AVALANCHE
+  }
+
+  return window.NETWORKS.ETHEREUM
+}
+
 const init_wallet = async function (callback) {
+
+  let targetNetwork = pageNetwork()
 
   if (window.web3Modal.cachedProvider) {
     await connectWallet(() => {})
   }
 
   if (walletProvider) {
-    _print_link("[CHANGE WALLET]", changeWallet, "connect_wallet_button");
-    start(callback);
+
+    let provider = new ethers.providers.Web3Provider(walletProvider)
+    let connectedNetwork = await provider.getNetwork()
+    let targetNetworkId = parseInt(targetNetwork.chainId, 16)
+
+    if (connectedNetwork.chainId === targetNetworkId) {
+      _print_link("[CHANGE WALLET]", changeWallet, "connect_wallet_button");
+      start(callback);
+    } else {
+      _print(`You are connected to ${networkNameFromId(connectedNetwork.chainId)}, please switch to ${targetNetwork.chainName} network`)
+      hideLoading()
+    }
   } else {
     _print_link("[CONNECT WALLET]", () => connectWallet(callback), "connect_wallet_button");
     hideLoading()
   }
-  _print('');
+  _print('')
 }
 
 async function init_ethers() {
@@ -93,7 +142,6 @@ async function init_ethers() {
 }
 
 const changeWallet = async function() {
-  console.log("change wallet")
   let cached = window.web3Modal.cachedProvider
   window.web3Modal.clearCachedProvider()
   await connectWallet(()=> window.location.reload() )
@@ -104,8 +152,8 @@ const changeWallet = async function() {
 
 const connectWallet = async function(callback) {
   try {
-    console.log("connect wallet")
     walletProvider = await window.web3Modal.connect()
+
     walletProvider.on("accountsChanged", (accounts) => {
       if (accounts === undefined || accounts.length === 0) {
         window.web3Modal.clearCachedProvider()
@@ -113,14 +161,33 @@ const connectWallet = async function(callback) {
       window.location.reload()
     });
 
-    let button = document.getElementById('connect_wallet_button')
-    button.textContent = "[CHANGE WALLET]"
-    $(document).off('click', '#connect_wallet_button')
-    $(document).on('click', '#connect_wallet_button', changeWallet)
+    walletProvider.on("chainChanged", (networkId) => {
+      window.location.reload()
+    });
 
-    showLoading()
+    let targetNetwork = pageNetwork()
+    let provider = new ethers.providers.Web3Provider(walletProvider)
+    let connectedNetwork = await provider.getNetwork()
+    let targetNetworkId = parseInt(targetNetwork.chainId, 16)
 
-    start(callback)
+    if (connectedNetwork.chainId === targetNetworkId) {
+      let button = document.getElementById('connect_wallet_button')
+      button.textContent = "[CHANGE WALLET]"
+      $(document).off('click', '#connect_wallet_button')
+      $(document).on('click', '#connect_wallet_button', changeWallet)
+
+      showLoading()
+
+      start(callback)
+    } else {
+
+      let button = document.getElementById('connect_wallet_button')
+      $(document).off('click', '#connect_wallet_button')
+      button.remove()
+
+      _print(`You are connected to ${networkNameFromId(connectedNetwork.chainId)}, please switch to ${targetNetwork.chainName} network`)
+      hideLoading()
+    }
 
   } catch(e) {}
 }


### PR DESCRIPTION
When wallet is connected the wrong network, a message is displayed to indicate which network is needed

![image](https://user-images.githubusercontent.com/8516712/117581639-3d350a00-b0fe-11eb-90cf-18efdbd637f2.png)

Page will detect network changes and adapt accordingly

If target network is not Ethereum, a SWITCH NETWORK appears to trigger the network change

![image](https://user-images.githubusercontent.com/8516712/117582942-e3840e00-b104-11eb-8344-b7cd01f85dff.png)

only available for Metamask browser plugin, and shows as following

![image](https://user-images.githubusercontent.com/8516712/117582972-09a9ae00-b105-11eb-9630-71550de6f3ea.png)
