### PR TITLE
Fix Issue #530

### DIFF
--- a/src/static/js/matic_helpers.js
+++ b/src/static/js/matic_helpers.js
@@ -42,7 +42,20 @@ async function getMatic20(App, token, address, stakingAddress) {
         tokens:[address]
       }
     }
-    const decimals = await token.decimals()
+    const decimals = await token.decimals();
+    if (address === "0x4c28f48448720e9000907BC2611F73022fdcE1fA") {
+      return {
+        address,
+        name : "Wrapped Matic",
+        symbol : "WMATIC",
+        totalSupply : await token.totalSupply(),
+        decimals : decimals,
+        staked:  await token.balanceOf(stakingAddress) / 10 ** decimals,
+        unstaked: await token.balanceOf(App.YOUR_ADDRESS)  / 10 ** decimals,
+        contract: token,
+        tokens : [address]
+      }
+    }
     return {
         address,
         name : await token.name(),


### PR DESCRIPTION
The problem:

The address 0x4c28f48448720e9000907BC2611F73022fdcE1fA

ethers contract call returns the name and symbol for this as "WETH" and "Wrapped ETH"
`const erc20 = new ethers.Contract(tokenAddress, ERC20_ABI, App.provider);`

Added a custom check for this address in the `getMatic20` function to put the correct name and symbol

Cross checked the response https://exchange.dfyn.network/ uses for populating their UI

![Screenshot from exchange.dfyn.network](https://user-images.githubusercontent.com/6171567/118370781-e8dece00-b5c6-11eb-807e-8bd1e32f2489.png)


This is first commit to this project. Apologies if the approach is wrong.
