### PR TITLE
Use Ascii table + modal for sushi farms

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -14,29 +14,33 @@ body, input {
 }
 
 .modal {
-  display: none; 
+  display: none;
   position: fixed;
-  z-index: 1; 
+  z-index: 1;
   left: 0;
   top: 0;
   width: 100%;
   height: 100%;
-  overflow: auto; 
-  background-color: rgb(0, 0, 0); 
-  background-color: rgba(0, 0, 0, 0.4); 
+  overflow: auto;
+  background-color: rgb(0, 0, 0);
+  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .modal-content {
   background-color: #fefefe;
-  margin: 15% auto; 
+  margin: 15% auto;
   border: 1px solid #888;
-  width: 80%; 
+  width: 80%;
+}
+
+.modal-close {
+  padding: 5px;
 }
 
 .modal-input {
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.2);   
+  background-color: rgba(0, 0, 0, 0.2);
   height: 40px;
   color: #000;
   padding: 8px 4px;
@@ -63,12 +67,12 @@ body, input {
   > li:hover {
     background: rgba(0,0,0,0.2)
   }
-  
+
 }
 
 @media (prefers-color-scheme: dark) {
   .modal {
-    background-color: rgba(255, 255, 255, 0.2);   
+    background-color: rgba(255, 255, 255, 0.2);
   }
 
   .modal-content {
@@ -76,7 +80,7 @@ body, input {
   }
 
   .modal-input {
-    background-color: rgba(255, 255, 255, 0.2);   
+    background-color: rgba(255, 255, 255, 0.2);
     color: #fff;
   }
 
@@ -87,8 +91,8 @@ body, input {
     }
   }
 
-  
-  
+
+
 
   body {
     background-color: #272727;

--- a/src/js/ascii-table.js
+++ b/src/js/ascii-table.js
@@ -94,7 +94,7 @@ AsciiTable.alignLeft = function(str, len, pad) {
 
   var strLen = str.length
   if (str.includes("href")) {
-    strLen = str.match(/.*>(.*)<\/a>/i)[1].length
+    strLen = str.match(/<a href.*?>(.*)<\/a>/i)[1].length
   }
 
   var alen = len + 1 - strLen
@@ -166,7 +166,7 @@ AsciiTable.alignAuto = function(str, len, pad) {
 
   var strLen = str.length
   if (str.includes("href")) {
-    strLen = str.match(/.*>(.*)<\/a>/i)[1].length
+    strLen = str.match(/<a href.*?>(.*)<\/a>/i)[1].length
   }
 
   if (strLen < len) {
@@ -527,6 +527,7 @@ AsciiTable.prototype.toString = function() {
       try {
         if (cell.includes("href")) {  // #eyo fix for href cell len
           cell = row[k].toString().match(/.*?>(.*)<\/a>/i)[1]
+
         } // else {cell = row[k]}
       } catch(err) { cell = row[k] }
       max[k] = Math.max(max[k], cell ? cell.toString().length : 0)

--- a/src/static/js/ethers_helper.js
+++ b/src/static/js/ethers_helper.js
@@ -1521,12 +1521,104 @@ function getUniPrices(tokens, prices, pool)
           [ `https://app.uniswap.org/#/add/${t0address}/${t1address}`,
             `https://app.uniswap.org/#/remove/${t0address}/${t1address}`,
             `https://app.uniswap.org/#/swap?inputCurrency=${t0address}&outputCurrency=${t1address}` ]
+
           const helperHrefs = helperUrls.length == 0 ? "" :
             ` <a href='${helperUrls[0]}' target='_blank'>[+]</a> <a href='${helperUrls[1]}' target='_blank'>[-]</a> <a href='${helperUrls[2]}' target='_blank'>[<=>]</a>`
           _print(`<a href='${poolUrl}' target='_blank'>${stakeTokenTicker}</a>${helperHrefs} Price: $${formatMoney(price)} TVL: $${formatMoney(tvl)}`);
           _print(`${t0.symbol} Price: $${displayPrice(p0)}`);
           _print(`${t1.symbol} Price: $${displayPrice(p1)}`);
           _print(`Staked: ${pool.staked.toFixed(decimals ?? 4)} ${pool.symbol} ($${formatMoney(staked_tvl)})`);
+        }
+      },
+      pair_links(chain="eth", decimals, customURLs) {
+        const t0address = t0.symbol == "ETH" ? "ETH" : t0.address;
+        const t1address = t1.symbol == "ETH" ? "ETH" : t1.address;
+        if (customURLs) {
+          const poolUrl = `${customURLs.info}/${pool.address}`
+          const helperUrls = [
+            `${customURLs.add}/${t0address}/${t1address}`,
+            `${customURLs.remove}/${t0address}/${t1address}`,
+            `${customURLs.swap}?inputCurrency=${t0address}&outputCurrency=${t1address}`
+          ]
+          return {
+            pair_link: `<a href='${poolUrl}' target='_blank'>${stakeTokenTicker}</a>`,
+            add_liquidity_link: `<a href='${helperUrls[0]}' target='_blank'>[+]</a>`,
+            remove_liquidity_link: `<a href='${helperUrls[1]}' target='_blank'>[-]</a>`,
+            swap_link: `<a href='${helperUrls[2]}' target='_blank'>[<=>]</a>`,
+            token0: t0.symbol,
+            price0: `$${displayPrice(p0)}`,
+            token1: t1.symbol,
+            price1: `$${displayPrice(p1)}`,
+            total_staked: `$${formatMoney(staked_tvl)}`
+          }
+        }
+        else {
+          const poolUrl = pool.is1inch ? "https://1inch.exchange/#/dao/pools" :
+            pool.symbol.includes("LSLP") ? `https://info.linkswap.app/pair/${pool.address}` :
+              pool.symbol.includes("SLP") ?  `http://analytics.sushi.com/pairs/${pool.address}` :
+                pool.symbol.includes("Cake") ?  `https://pancakeswap.info/pair/${pool.address}` :
+                  pool.symbol.includes("PGL") ?  `https://info.pangolin.exchange/#/pair/${pool.address}` :
+                    pool.symbol.includes("CS-LP") ?  `https://app.coinswap.space/#/` :
+                      pool.name.includes("Value LP") ?  `https://info.vswap.fi/pool/${pool.address}` :
+                        chain == "matic" ? `https://info.quickswap.exchange/pair/${pool.address}` :
+                          `http://uniswap.info/pair/${pool.address}`;
+          const helperUrls = pool.is1inch ? [] :
+            pool.symbol.includes("LSLP") ? [
+                `https://linkswap.app/#/add/${t0address}/${t1address}`,
+                `https://linkswap.app/#/remove/${t0address}/${t1address}`,
+                `https://linkswap.app/#/swap?inputCurrency=${t0address}&outputCurrency=${t1address}`
+              ] :
+              pool.symbol.includes("Cake") ? [
+                  `https://exchange.pancakeswap.finance/#/add/${t0address}/${t1address}`,
+                  `https://exchange.pancakeswap.finance/#/remove/${t0address}/${t1address}`,
+                  `https://exchange.pancakeswap.finance/#/swap?inputCurrency=${t0address}&outputCurrency=${t1address}`
+                ] :
+                chain=='matic'? [
+                    `https://quickswap.exchange/#/add/${t0address}/${t1address}`,
+                    `https://quickswap.exchange/#/remove/${t0address}/${t1address}`,
+                    `https://quickswap.exchange/#/swap?inputCurrency=${t0address}&outputCurrency=${t1address}`
+                  ] :
+                  pool.name.includes("Value LP") ? [
+                      `https://bsc.valuedefi.io/#/add/${t0address}/${t1address}`,
+                      `https://bsc.valuedefi.io/#/remove/${t0address}/${t1address}`,
+                      `https://bsc.valuedefi.io/#/swap?inputCurrency=${t0address}&outputCurrency=${t1address}`
+                    ] :
+                    pool.symbol.includes("PGL") ? [
+                        `https://app.pangolin.exchange/#/add/${t0address}/${t1address}`,
+                        `https://app.pangolin.exchange/#/remove/${t0address}/${t1address}`,
+                        `https://app.pangolin.exchange/#/swap?inputCurrency=${t0address}&outputCurrency=${t1address}`
+                      ] :
+                      pool.symbol.includes("CS-LP") ? [
+                          `https://app.coinswap.space/#/add/${t0address}/${t1address}`,
+                          `https://app.coinswap.space/#/remove/${t0address}/${t1address}`,
+                          `https://app.coinswap.space/#/swap?inputCurrency=${t0address}&outputCurrency=${t1address}`
+                        ] :
+                        pool.symbol.includes("SLP") ? [
+                            `https://app.sushi.com/add/${t0address}/${t1address}`,
+                            `https://app.sushi.com/remove/${t0address}/${t1address}`,
+                            `https://app.sushi.com/swap?inputCurrency=${t0address}&outputCurrency=${t1address}`
+                          ] :
+                          t0.symbol.includes("COMFI") ? [
+                              `https://app.uniswap.org/#/add/v2/${t0address}/${t1address}`,
+                              `https://app.uniswap.org/#/remove/v2/${t0address}/${t1address}`,
+                              `https://app.uniswap.org/#/swap?inputCurrency=${t0address}&outputCurrency=${t1address}`
+                            ] :
+                            [ `https://app.uniswap.org/#/add/${t0address}/${t1address}`,
+                              `https://app.uniswap.org/#/remove/${t0address}/${t1address}`,
+                              `https://app.uniswap.org/#/swap?inputCurrency=${t0address}&outputCurrency=${t1address}` ]
+
+          return {
+            pair_link: `<a href='${poolUrl}' target='_blank'>${stakeTokenTicker}</a>`,
+            add_liquidity_link: `<a href='${helperUrls[0]}' target='_blank'>[+]</a>`,
+            remove_liquidity_link: `<a href='${helperUrls[1]}' target='_blank'>[-]</a>`,
+            swap_link: `<a href='${helperUrls[2]}' target='_blank'>[<=>]</a>`,
+            token0: t0.symbol,
+            price0: `$${displayPrice(p0)}`,
+            token1: t1.symbol,
+            price1: `$${displayPrice(p1)}`,
+            total_staked: `$${formatMoney(staked_tvl)}`
+          }
+
         }
       },
       print_contained_price(userStaked) {
@@ -1586,6 +1678,27 @@ function getValuePrices(tokens, prices, pool)
         _print(`${t0.symbol} Price: $${formatMoney(p0)}`)
         _print(`${t1.symbol} Price: $${formatMoney(p1)}`)
         _print(`Staked: ${pool.staked.toFixed(4)} ${pool.symbol} ($${formatMoney(staked_tvl)})`);
+      },
+      pair_links() {
+        const poolUrl = `https://info.vswap.fi/pool/${pool.address}`
+        const t0address = t0.address;
+        const t1address =  t1.address;
+        const helperUrls = [
+          `https://bsc.valuedefi.io/#/add/${pool.address}`,
+          `https://bsc.valuedefi.io/#/remove/${pool.address}`,
+          `https://bsc.valuedefi.io/#/vswap?inputCurrency=${t0address}&outputCurrency=${t1address}`
+        ]
+        return {
+          pair_link: `<a href='${poolUrl}' target='_blank'>${stakeTokenTicker}</a>`,
+          add_liquidity_link: `<a href='${helperUrls[0]}' target='_blank'>[+]</a>`,
+          remove_liquidity_link: `<a href='${helperUrls[1]}' target='_blank'>[-]</a>`,
+          swap_link: `<a href='${helperUrls[2]}' target='_blank'>[<=>]</a>`,
+          token0: t0.symbol,
+          price0: `$${displayPrice(p0)}`,
+          token1: t1.symbol,
+          price1: `$${displayPrice(p1)}`,
+          total_staked: `$${formatMoney(staked_tvl)}`
+        }
       },
       print_contained_price(userStaked) {
         var userPct = userStaked / pool.totalSupply;
@@ -1736,6 +1849,17 @@ function getErc20Prices(prices, pool, chain="eth") {
     print_price() {
       _print(`${name} Price: $${displayPrice(price)} Market Cap: $${formatMoney(tvl)}`);
       _print(`Staked: ${pool.staked.toFixed(4)} ${pool.symbol} ($${formatMoney(staked_tvl)})`);
+    },
+    pair_links() {
+      return {
+        pair_link: name,
+        add_liquidity_link: "",
+        remove_liquidity_link: "",
+        swap_link: "",
+        price0: "",
+        price1: "",
+        total_staked: `$${formatMoney(staked_tvl)}`
+      }
     },
     print_contained_price() {
     }

--- a/src/static/js/pool_table_helpers.js
+++ b/src/static/js/pool_table_helpers.js
@@ -1,0 +1,233 @@
+
+
+async function printChefContractPoolsTable(title, App, chef, chefAddress, chefAbi, rewardTokenTicker,
+                                rewardTokenFunction, rewardsPerBlockFunction, rewardsPerWeekFixed, pendingRewardsFunction,
+                                extraPrices, deathPoolIndices, showAll) {
+
+  let tableData = {
+    "title": title,
+    "heading": [
+      "#",
+      "Pair",
+      "Total Staked",
+      "Reward",
+      "APR",
+      "My Stake",
+    ],
+    "rows": []
+  }
+
+  const chefContract = chef ?? new ethers.Contract(chefAddress, chefAbi, App.provider);
+
+  const poolCount = parseInt(await chefContract.poolLength(), 10);
+  const totalAllocPoints = await chefContract.totalAllocPoint();
+
+  _print(`<a href='https://etherscan.io/address/${chefAddress}' target='_blank'>Staking Contract</a>`);
+  _print(`Found ${poolCount} pools.\n`)
+
+  _print(`Showing incentivized pools only.\n`);
+
+  var tokens = {};
+
+  const rewardTokenAddress = await chefContract.callStatic[rewardTokenFunction]();
+  const rewardToken = await getToken(App, rewardTokenAddress, chefAddress);
+  const rewardsPerWeek = rewardsPerWeekFixed ??
+    await chefContract.callStatic[rewardsPerBlockFunction]()
+    / 10 ** rewardToken.decimals * 604800 / 13.5
+
+  const poolInfos = await Promise.all([...Array(poolCount).keys()].map(async (x) => {
+    try {
+      return await getPoolInfo(App, chefContract, chefAddress, x, pendingRewardsFunction, showAll);
+    }
+    catch (ex) {
+      console.log(`Error loading pool ${x}: ${ex}`);
+      return null;
+    }
+  }));
+
+  var tokenAddresses = [].concat.apply([], poolInfos.filter(x => x?.poolToken).map(x => x.poolToken.tokens));
+  var prices = await lookUpTokenPrices(tokenAddresses);
+  if (extraPrices) {
+    for (const [k,v] of Object.entries(extraPrices)) {
+      if (v.usd) {
+        prices[k] = v
+      }
+    }
+  }
+
+  await Promise.all(tokenAddresses.map(async (address) => {
+    tokens[address] = await getToken(App, address, chefAddress);
+  }));
+
+  if (deathPoolIndices) {
+    deathPoolIndices.map(i => poolInfos[i])
+      .map(poolInfo =>
+        poolInfo.poolToken ? getPoolPrices(tokens, prices, poolInfo.poolToken, "eth") : undefined);
+  }
+
+  const poolPrices = poolInfos.map(poolInfo => poolInfo?.poolToken ? getPoolPrices(tokens, prices, poolInfo.poolToken) : undefined);
+
+  _print("Finished reading smart contracts.\n");
+
+  for (let i = 0; i < poolCount; i++) {
+    if (poolPrices[i]) {
+      let pool = buildChefPool(App, chefAbi, chefAddress, prices, tokens, poolInfos[i], i, poolPrices[i],
+        totalAllocPoints, rewardsPerWeek, rewardTokenTicker, rewardTokenAddress,
+        pendingRewardsFunction)
+
+      if (pool) {
+        tableData.rows.push([
+          _build_link(`${i}`, () => {
+            document.getElementById("pool-details-modal").style.display = 'block'
+
+            let table = new AsciiTable();
+
+            let tableData = {
+              "title": pool.pair_link,
+              "rows": []
+            }
+            table.addRow(["Pair", pool.pair_link])
+
+            if (pool.add_liquidity_link) {
+              table.addRow(["Add Liquidity", pool.add_liquidity_link])
+              table.addRow(["Remove Liquidity", pool.remove_liquidity_link])
+              table.addRow(["Swap", pool.swap_link])
+              table.addRow([`${pool.token0} Price`, pool.price0])
+              table.addRow([`${pool.token1} Price`, pool.price1])
+            }
+
+            table.addRow([`${pool.reward_token} Weekly rewards`, pool.weekly_rewards])
+            table.addRow(["Total staked", pool.total_staked])
+            table.addRow(["My stake", pool.user_stake])
+            table.addRow(["DPR", pool.dpr])
+            table.addRow(["WPR", pool.wpr])
+            table.addRow(["APR", pool.apr])
+            table.addRow(["Stake", pool.stake])
+            table.addRow(["Unstake", pool.unstake])
+            table.addRow(["Claim", pool.claim])
+
+            document.getElementById('pool-details-content').innerHTML += table + '<br />';
+
+          }),
+          _truncate_link(pool.pair_link.replace(/\u0000/g,""), 20),
+          pool.total_staked,
+          pool.reward_token,
+          pool.apr,
+          pool.user_stake,
+        ])
+
+      }
+    }
+  }
+
+  let table = new AsciiTable().fromJSON(tableData);
+  document.getElementById('log').innerHTML += table + '<br />';
+
+}
+
+function buildChefPool(App, chefAbi, chefAddr, prices, tokens, poolInfo, poolIndex, poolPrices,
+                       totalAllocPoints, rewardsPerWeek, rewardTokenTicker, rewardTokenAddress,
+                       pendingRewardsFunction, fixedDecimals, claimFunction, chain="eth") {
+  fixedDecimals = fixedDecimals ?? 2;
+  const sp = (poolInfo.stakedToken == null) ? null : getPoolPrices(tokens, prices, poolInfo.stakedToken);
+  var poolRewardsPerWeek = poolInfo.allocPoints / totalAllocPoints * rewardsPerWeek;
+  if (poolRewardsPerWeek === 0 && rewardsPerWeek !== 0) return;
+  const userStaked = poolInfo.userLPStaked ?? poolInfo.userStaked;
+  const rewardPrice = getParameterCaseInsensitive(prices, rewardTokenAddress)?.usd;
+  const staked_tvl = sp?.staked_tvl ?? poolPrices.staked_tvl;
+
+  let priceLinks = poolPrices.pair_links(chain);
+
+  let apr = buildAPR(rewardTokenTicker, rewardPrice, poolRewardsPerWeek, poolPrices.stakeTokenTicker,
+    staked_tvl, userStaked, poolPrices.price, fixedDecimals);
+
+  let actions =
+    buildChefContractLinks(App, chefAbi, chefAddr, poolIndex, poolInfo.address, pendingRewardsFunction,
+      rewardTokenTicker, poolPrices.stakeTokenTicker, poolInfo.poolToken.unstaked,
+      poolInfo.userStaked, poolInfo.pendingRewardTokens, fixedDecimals, claimFunction, rewardPrice, chain);
+
+  return {
+    reward_token: apr.reward_token,
+    pair_link: priceLinks.pair_link,
+    add_liquidity_link: priceLinks.add_liquidity_link,
+    remove_liquidity_link: priceLinks.remove_liquidity_link,
+    swap_link: priceLinks.swap_link,
+    token0: priceLinks.token0,
+    price0: priceLinks.price0,
+    token1: priceLinks.token1,
+    price1: priceLinks.price1,
+    total_staked: priceLinks.total_staked,
+    weekly_rewards: apr.weekly_rewards,
+    dpr: apr.dpr,
+    wpr: apr.wpr,
+    apr: apr.apr,
+    user_stake: apr.user_stake,
+    stake: actions.stake,
+    unstake: actions.unstake,
+    claim: actions.claim,
+  };
+}
+
+function buildAPR(rewardTokenTicker, rewardPrice, poolRewardsPerWeek,
+                  stakeTokenTicker, staked_tvl, userStaked, poolTokenPrice,
+                  fixedDecimals) {
+  var usdPerWeek = poolRewardsPerWeek * rewardPrice;
+  fixedDecimals = fixedDecimals ?? 2;
+  var weeklyAPR = usdPerWeek / staked_tvl * 100;
+  var dailyAPR = weeklyAPR / 7;
+  var yearlyAPR = weeklyAPR * 52;
+  var userStakedUsd = userStaked * poolTokenPrice;
+  var userStakedPct = userStakedUsd / staked_tvl * 100;
+
+  return {
+    reward_token: rewardTokenTicker,
+    weekly_rewards: `${poolRewardsPerWeek.toFixed(fixedDecimals)} ($${formatMoney(usdPerWeek)})`,
+    dpr: `${dailyAPR.toFixed(2)}%`,
+    wpr: `${weeklyAPR.toFixed(2)}%`,
+    apr: `${yearlyAPR.toFixed(2)}%`,
+    user_stake: `${userStaked.toFixed(fixedDecimals)} ($${formatMoney(userStakedUsd)}), ${userStakedPct.toFixed(2)}%`
+  }
+}
+
+function buildChefContractLinks(App, chefAbi, chefAddr, poolIndex, poolAddress, pendingRewardsFunction,
+                                rewardTokenTicker, stakeTokenTicker, unstaked, userStaked, pendingRewardTokens, fixedDecimals,
+                                claimFunction, rewardTokenPrice) {
+  fixedDecimals = fixedDecimals ?? 2;
+  const approveAndStake = async function() {
+    return chefContract_stake(chefAbi, chefAddr, poolIndex, poolAddress, App)
+  }
+  const unstake = async function() {
+    return chefContract_unstake(chefAbi, chefAddr, poolIndex, App, pendingRewardsFunction)
+  }
+  const claim = async function() {
+    return chefContract_claim(chefAbi, chefAddr, poolIndex, App, pendingRewardsFunction, claimFunction)
+  }
+  let stakeLink = _build_link(`${unstaked.toFixed(fixedDecimals)}`, approveAndStake)
+  let unstakeLink = _build_link(`${userStaked.toFixed(fixedDecimals)}`, unstake)
+  let claimLink = _build_link(`${pendingRewardTokens.toFixed(fixedDecimals)} ($${formatMoney(pendingRewardTokens*rewardTokenPrice)})`, claim)
+
+  return { stake: stakeLink, unstake: unstakeLink, claim: claimLink }
+}
+
+const _build_link = function(message, onclickFunction, uuid = ID()) {
+
+  let link = '<a href="#" id=' + uuid + '>' + message + '</a>'
+
+  $(document).on('click', '#' + uuid, function() {
+    onclickFunction()
+    return false
+  })
+
+  return link
+}
+
+const _truncate_link = function (link, maxLength) {
+    let text = link.match(/<a href.*?>(.*)<\/a>/i)[1]
+
+    if (text.length > maxLength) {
+      let replacementText = text.substr(0, maxLength - 3) + "..."
+      return link.slice().replace(text, replacementText)
+    }
+
+    return link
+}

--- a/src/static/js/sushi.js
+++ b/src/static/js/sushi.js
@@ -1,5 +1,5 @@
 $(function() {
-consoleInit(main)
+    consoleInit(main)
   });
 
   async function main() {
@@ -13,7 +13,7 @@ consoleInit(main)
     const SUSHI_CHEF = new ethers.Contract(SUSHI_CHEF_ADDR, SUSHI_CHEF_ABI, App.provider);
     const rewardsPerWeek = await SUSHI_CHEF.sushiPerBlock() / 1e18 * 604800 / 13.5;
 
-    await loadChefContract(App, SUSHI_CHEF, SUSHI_CHEF_ADDR, SUSHI_CHEF_ABI,
+    await printChefContractPoolsTable("Sushi", App, SUSHI_CHEF, SUSHI_CHEF_ADDR, SUSHI_CHEF_ABI,
         "SUSHI", "sushi", null, rewardsPerWeek, "pendingSushi");
 
     hideLoading();

--- a/src/static/js/sushi_all.js
+++ b/src/static/js/sushi_all.js
@@ -13,7 +13,7 @@ consoleInit(main)
     const SUSHI_CHEF = new ethers.Contract(SUSHI_CHEF_ADDR, SUSHI_CHEF_ABI, App.provider);
     const rewardsPerWeek = await SUSHI_CHEF.sushiPerBlock() / 1e18 * 604800 / 13.5;
 
-    await loadChefContract(App, SUSHI_CHEF, SUSHI_CHEF_ADDR, SUSHI_CHEF_ABI,
+    await printChefContractPoolsTable("Sushi", App, SUSHI_CHEF, SUSHI_CHEF_ADDR, SUSHI_CHEF_ABI,
         "SUSHI", "sushi", null, rewardsPerWeek, "pendingSushi", null, null, true);
 
     hideLoading();

--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -40,3 +40,4 @@
     <link rel="manifest" href="<%= PP %>/manifest.json">
 </head>
 <%- include(`${partials}/quick`); -%>
+<%- include(`${partials}/pool_details_modal`); -%>

--- a/src/views/partials/header_main.ejs
+++ b/src/views/partials/header_main.ejs
@@ -3,3 +3,4 @@
 </div>
 <%- include(`${partials}/clear_storage`); -%>
 <%- include(`${partials}/quick`); -%>
+<%- include(`${partials}/pool_details_modal`); -%>

--- a/src/views/partials/pool_details_modal.ejs
+++ b/src/views/partials/pool_details_modal.ejs
@@ -1,0 +1,15 @@
+<div id="pool-details-modal" class="modal">
+
+    <div class="modal-content" id="pool-details">
+        <a href="#" class="modal-close" id="close-pool-details-modal">Close</a><br/>
+        <pre id="pool-details-content"></pre>
+    </div>
+</div>
+<script>
+    document
+        .getElementById("close-pool-details-modal")
+        .onclick = () => {
+            document.getElementById("pool-details-modal").style.display = 'none'
+            document.getElementById("pool-details-content").innerHTML = ''
+        }
+</script>

--- a/src/views/partials/scripts.ejs
+++ b/src/views/partials/scripts.ejs
@@ -12,6 +12,7 @@
     <script src="<%= PP %>/js/<%= filenameMap['xdai_helpers.js'] %>"></script>
     <script src="<%= PP %>/js/<%= filenameMap['fantom_helpers.js'] %>"></script>
     <script src="<%= PP %>/js/<%= filenameMap['harmony_helpers.js'] %>"></script>
+    <script src="<%= PP %>/js/<%= filenameMap['pool_table_helpers.js'] %>"></script>
     <% if(locals.scriptname) { %>
         <script src="<%= PP %>/js/<%= filenameMap[locals.scriptname + ".js"] %>"></script>
     <% } %>
@@ -29,6 +30,7 @@
     <script src="<%= PP %>/js/xdai_helpers.js"></script>
     <script src="<%= PP %>/js/fantom_helpers.js"></script>
     <script src="<%= PP %>/js/harmony_helpers.js"></script>
+    <script src="<%= PP %>/js/pool_table_helpers.js"></script>
     <% if(locals.scriptname) { %>
         <script src="<%= PP %>/js/<%= locals.scriptname %>.js"></script>
     <% } %>


### PR DESCRIPTION
Changed sushi page to list pools with a compressed ascii table, with main info for each pool

![image](https://user-images.githubusercontent.com/8516712/118402802-d79bcd00-b66b-11eb-96ca-cd20215b8958.png)

Clicking on the pool index opens a modal with all pool info/links

![image](https://user-images.githubusercontent.com/8516712/118402827-ed10f700-b66b-11eb-8a57-4affc2f5785c.png)
