### PR TITLE
Added SPORE Staking rewards to AVAX PNG 

### DIFF
--- a/src/static/js/avax_png.js
+++ b/src/static/js/avax_png.js
@@ -89,4 +89,10 @@ const PngStakingContracts= [
     {
         stakingRewardAddress: '0xc7D0E29b616B29aC6fF4FD5f37c8Da826D16DB0D'
     },
+    {
+        stakingRewardAddress: '0x12A33F6B0dd0D35279D402aB61587fE7eB23f7b0'
+    },
+    {
+        stakingRewardAddress: '0xd3e5538A049FcFcb8dF559B85B352302fEfB8d7C'
+    },
 ]


### PR DESCRIPTION
Following the latest PNG rewards update, I added the latest SPORE pools that yield PNG rewards