### PR TITLE
Remove bonus multiplier from Bundle rewards calculation

### DIFF
--- a/src/static/js/bsc_bundle.js
+++ b/src/static/js/bsc_bundle.js
@@ -17,14 +17,13 @@ async function main() {
 
    const startBlock = await BDL_CHEF.startBlock();
    const currentBlock = await App.provider.getBlockNumber();
-   const bonusMultiplier = await BDL_CHEF.bonusMultiplier();
 
    let rewardsPerWeek = 0
    if(currentBlock < startBlock){
      _print(`Rewards start at block ${startBlock}\n`);
    }else{
     rewardsPerWeek = await BDL_CHEF.blockRewards() /1e18
-        * 604800 / 3 * bonusMultiplier;
+        * 604800 / 3;
    }
 
     const tokens = {};


### PR DESCRIPTION
Rewards calculation for Bundle was using a bonus rewards multiplier. The bonus rewards period has since passed and can no longer be re-activated; as a result, this is leading to an inflated APR on vfat.