### PR TITLE
Fix Sunrise and SunsetV2 native price data

### DIFF
--- a/src/static/js/matic_sunrise.js
+++ b/src/static/js/matic_sunrise.js
@@ -30,7 +30,7 @@ async function main() {
   const prices = await getMaticPrices();
 
   await loadMaticChefContract(App, tokens, prices, SUNRISE_CHEF, SUNRISE_CHEF_ADDR, SUNRISE_CHEF_ABI,
-    rewardTokenTicker, "SUNSETToken", null, rewardsPerWeek, "pendingSUNSET");
+    rewardTokenTicker, "SUNSETToken", null, rewardsPerWeek, "pendingSUNSET", [0]);
 
   hideLoading();
 }

--- a/src/static/js/matic_sunsetv2.js
+++ b/src/static/js/matic_sunsetv2.js
@@ -31,7 +31,7 @@ async function main() {
   const prices = await getMaticPrices();
 
   await loadMaticChefContract(App, tokens, prices, SUNV2_CHEF, SUNV2_CHEF_ADDR, SUNV2_CHEF_ABI,
-    rewardTokenTicker, "SUNSETToken", null, rewardsPerWeek, "pendingSUNSET");
+    rewardTokenTicker, "SUNSETToken", null, rewardsPerWeek, "pendingSUNSET", [17]);
 
   hideLoading();
 }


### PR DESCRIPTION
Added SUNRISE and SUNSET native LPs to deathPoolIndices in the default contract loader in order to fix native token stats not being grabbed properly. Can't do much about partnered tokens with LPs that aren't on the MasterChef for now, unfortunately.

I would appreciate any insight or tips on potential workarounds or tips to address that issue. It seems like a custom contract loader in the project file is the way to go.