### PR TITLE
Fixed a typo

### DIFF
--- a/src/views/pages/avax/dregg/index.ejs
+++ b/src/views/pages/avax/dregg/index.ejs
@@ -7,7 +7,7 @@
 <pre id="log">
 ***************************** AVALANCHE ************************************
 
-*************** 👨‍🌾 OFFICIAL FROST FINANCE FARMING CALCULATOR 👨‍🌾 ***********
+*************** 👨‍🌾 OFFICIAL DRAGONS LAIR FARMING CALCULATOR 👨‍🌾 ***********
 Website  : <a href="https://thedragonslair.farm/">https://thedragonslair.farm/</a>
 Docs     : <a href="https://docs.thedragonslair.farm/">https://docs.thedragonslair.farm/</a>
 Telegram : <a href="https://t.me/thedragonslairfarm">https://t.me/thedragonslairfarm</a>


### PR DESCRIPTION
Fixed a type in our VFAT page that mentions FROST instead of The dragons lair.