### PR TITLE
fix ald pool reward rate

### DIFF
--- a/src/static/js/ald.js
+++ b/src/static/js/ald.js
@@ -20,7 +20,7 @@ consoleInit(main)
      _print(`Rewards start at block <a href="https://etherscan.com/block/countdown/${startBlock}" target="_blank">${startBlock}</a>\n`)
     }else{
      rewardsPerWeek = await ALD_CHEF.aldPerBlock() / 1e18 * 604800 / 13.5 
-      * await ALD_CHEF.tokenDistributorAllocNume() / await ALD_CHEF.tokenDistributorAllocDenom();
+      * (1 - await ALD_CHEF.tokenDistributorAllocNume() / await ALD_CHEF.tokenDistributorAllocDenom());
     }
 
     let p = await loadAldChefContract(App, ALD_CHEF, ALD_CHEF_ADDR, ALD_CHEF_ABI,


### PR DESCRIPTION
only `(1 - 7070/10000)` part is for user staking rewards

check https://github.com/AladdinDAO/aladdin-contracts/blob/main/contracts/token/TokenMaster.sol#L101

```js
uint256 distributorReward = aldReward.mul(tokenDistributorAllocNume).div(tokenDistributorAllocDenom);
uint256 poolReward = aldReward.sub(distributorReward);
accALDPerShare = accALDPerShare.add(poolReward.mul(1e18).div(lpSupply));
```