### PR TITLE
fix: nerd farm javascript

### DIFF
--- a/src/static/js/arbitrum_nerd.js
+++ b/src/static/js/arbitrum_nerd.js
@@ -3,7 +3,7 @@ $(function () {
 });
 
 
-const CHEF_ABI = [[
+const CHEF_ABI = [
   {
     "inputs": [
       {


### PR DESCRIPTION
A character in the ABI was breaking the JS for our farm, the nerd farm.
This PR fixes the JS.