### PR TITLE
Add Tristero AUSD vault page

### DIFF
--- a/src/static/js/pages.js
+++ b/src/static/js/pages.js
@@ -40,6 +40,7 @@ const main = async () => {
       ["Stabilize                    ", `<a href="stabilize/"         >Various</a>`, "STBZ               ", "https://stabilize.finance"],
       ["StakeDAO                     ", `<a href="stakedao/"          >Various</a>`, "SDT                ", "https://stakedao.org"],
       ["TrueFi                       ", `<a href="truefi/"            >Various</a>`, "TRU                ", "https://app.truefi.io/farm"],
+      ["Tristero AUSD                ", `<a href="tristero/"          >AUSD</a>`, "AUSD               ", "https://app.tristero.com"],
       ["Updown                       ", `<a href="updown"             >Various</a>`, "UPDOWN             ", "https://updown.finance"],
       ["Vtd                          ", `<a href="vtd"                >Various</a>`, "VTD                ", "https://vtd.finance/app"],
       ["Xusd                         ", `<a href="xusd"               >Various</a>`, "XUSD               ", "https://xusd.money"],

--- a/src/static/js/tristero.js
+++ b/src/static/js/tristero.js
@@ -49,7 +49,6 @@ async function main() {
   _print(`Configured lender rate: ${ratePerSecond} per second`)
   _print(`APR: ${apr.toFixed(4)}%`)
   _print(`APY: ${apy.toFixed(4)}% (daily compounding)`)
-  _print("\nThis page is read-only. The vault uses custom margin-lending accounting rather than VFAT's standard farming interfaces.")
 
   hideLoading()
 }

--- a/src/static/js/tristero.js
+++ b/src/static/js/tristero.js
@@ -1,0 +1,55 @@
+$(function() {
+  consoleInit(main)
+})
+
+const TRISTERO_VAULT = "0xB49781E8c39c75f413C1178f395bF68b0BEE8d00"
+const AUSD = "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a"
+const SECONDS_PER_YEAR = 365 * 24 * 60 * 60
+const DAYS_PER_YEAR = 365
+
+const TRISTERO_VAULT_ABI = [
+  "function getTVOL(address asset) view returns (uint256)",
+  "function assets(uint256 assetId) view returns (uint256 ratePerSecond, uint256 index, uint256 lastUpdate)"
+]
+
+const ERC20_ABI = [
+  "function decimals() view returns (uint8)",
+  "function symbol() view returns (string)"
+]
+
+async function main() {
+  const App = await init_ethers()
+  const vault = new ethers.Contract(TRISTERO_VAULT, TRISTERO_VAULT_ABI, App.provider)
+  const token = new ethers.Contract(AUSD, ERC20_ABI, App.provider)
+  const assetId = ethers.BigNumber.from(AUSD)
+
+  _print("*************** TRISTERO AUSD MARGIN VAULT ***************")
+  _print_href("Open Tristero app", "https://app.tristero.com")
+  _print_href("View vault contract", `https://etherscan.io/address/${TRISTERO_VAULT}`)
+  _print("Reading Ethereum contracts...\n")
+
+  const [tvol, assetInfo, decimals, symbol, prices] = await Promise.all([
+    vault.getTVOL(AUSD),
+    vault.assets(assetId),
+    token.decimals(),
+    token.symbol(),
+    lookUpTokenPrices([AUSD])
+  ])
+
+  const tokenPrice = getParameterCaseInsensitive(prices, AUSD)?.usd ?? 0
+  const assets = Number(ethers.utils.formatUnits(tvol, decimals))
+  const tvl = assets * tokenPrice
+  const ratePerSecond = Number((assetInfo.ratePerSecond ?? assetInfo[0]).toString())
+  const apr = ratePerSecond * SECONDS_PER_YEAR / 1e18 * 100
+  const apy = (Math.pow(1 + apr / 100 / DAYS_PER_YEAR, DAYS_PER_YEAR) - 1) * 100
+
+  _print_bold(`TVL: $${formatMoney(tvl)}`)
+  _print(`Assets: ${assets.toFixed(6)} ${symbol}`)
+  _print(`Asset price: $${tokenPrice.toFixed(6)}`)
+  _print(`Configured lender rate: ${ratePerSecond} per second`)
+  _print(`APR: ${apr.toFixed(4)}%`)
+  _print(`APY: ${apy.toFixed(4)}% (daily compounding)`)
+  _print("\nThis page is read-only. The vault uses custom margin-lending accounting rather than VFAT's standard farming interfaces.")
+
+  hideLoading()
+}

--- a/src/views/pages/tristero/index.ejs
+++ b/src/views/pages/tristero/index.ejs
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<%- include(`${partials}/head`); -%>
+
+<body>
+<%- include(`${partials}/header_main`); -%>
+<pre id="log">
+**************** TRISTERO AUSD MARGIN VAULT ****************
+</pre>
+<div class="loader--1"></div>
+<%- include(`${partials}/scripts`, {scriptname: 'tristero'}); -%>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add a read-only Tristero AUSD margin-vault page to VFAT.
- Read live Ethereum TVL from `getTVOL(AUSD)`.
- Derive APR from the vault’s configured `ratePerSecond` and standard daily-compounded APY.
- Register the page on the VFAT front page with links to Tristero and Etherscan.

## Design note

This vault uses custom margin-lending accounting rather than VFAT’s standard farming interfaces, so the page intentionally exposes read-only metrics and does not add deposit/withdraw actions.

## Validation

- `git diff --check` passes.
- The VFAT webpack build was not run because Node/npm dependencies are not installed in the checkout.